### PR TITLE
Add fine-grained seek commands

### DIFF
--- a/CoqInteractive.sublime-settings
+++ b/CoqInteractive.sublime-settings
@@ -15,4 +15,7 @@
     //    open Coq file.
     //
     "view_style": "inline",
+
+    // When sending commands to Coq, move the cursor to the end of the command.
+    "move_cursor_after_command": true
 }

--- a/coq.py
+++ b/coq.py
@@ -241,6 +241,27 @@ def find_first_coq_command(text, start=0, end=None):
 
     return None
 
+def find_last_coq_command(text, start=0, end=None):
+    """Find the last full Coq command in `text[start:end]`.
+
+    The return value is the index one past the end of the second-to-last
+    command, which is suitable to rewind, or None if there is no full command.
+
+    This is a naive version that parses all of the buffer.
+    """
+
+    end_of_previous = None
+    while True:
+        end_of_current = find_first_coq_command(text, start, end)
+
+        if end_of_current is None:
+            return end_of_previous
+        else:
+            end_of_previous = start
+            start = end_of_current
+
+    return None
+
 
 def pr(e, depth=0):
     print("{}{}".format(" " * depth, e))


### PR DESCRIPTION
This PR adds new commands `coq_seek_next`, `coq_seek_prev`, `coq_seek_start` and `coq_seek_end` (unbound by default) that reproduce the step-by-step evaluation behavior of CoqIDE.

In addition, it adds a new setting `move_cursor_after_command` which places the cursor after evaluated code and scrolls down the view along the way (enabled by default). This is relevant because unlike the basic `coq` command the high water mark is generally not at the cursor.

I'm not sure how to properly keep and access the settings; I went for a global variable for simplicity. The `coq_seek_prev` command has to find the end of the *previous* command, which I do naively by parsing the buffer forwards; for performance we could bisect with a little bit of backtracking or try backwards lexing.

I'm considering switching from CoqIDE; if it works out I'll probably have more things to contribute :smiley:  