### PR TITLE
Display all focused goals

### DIFF
--- a/CoqInteractive.sublime-settings
+++ b/CoqInteractive.sublime-settings
@@ -19,7 +19,7 @@
     // When sending commands to Coq, move the cursor to the end of the command.
     "move_cursor_after_command": true,
 
-    // Goals to show when display the current state:
+    // Goals to show when displaying the current state:
     //
     //  - "primary": the absolute current goal, always only one
     //

--- a/CoqInteractive.sublime-settings
+++ b/CoqInteractive.sublime-settings
@@ -17,5 +17,13 @@
     "view_style": "inline",
 
     // When sending commands to Coq, move the cursor to the end of the command.
-    "move_cursor_after_command": true
+    "move_cursor_after_command": true,
+
+    // Goals to show when display the current state:
+    //
+    //  - "primary": the absolute current goal, always only one
+    //
+    //  - "current": all currently-focused goals (like CoqIDE)
+    //
+    "show_goals": "current"
 }

--- a/CoqInteractive.sublime-settings
+++ b/CoqInteractive.sublime-settings
@@ -23,7 +23,7 @@
     //
     //  - "primary": the absolute current goal, always only one
     //
-    //  - "current": all currently-focused goals (like CoqIDE)
+    //  - "focused": all currently-focused goals (like CoqIDE)
     //
-    "show_goals": "current"
+    "show_goals": "focused"
 }

--- a/coq.py
+++ b/coq.py
@@ -328,7 +328,7 @@ def format_response(rp):
         else:
             return feedback + "No more goals."
 
-    if settings.get("show_goals", "current") == "primary":
+    if settings.get("show_goals", "focused") == "primary":
         goals_to_show = [primary_goal] if primary_goal else []
     else:
         goals_to_show = focused_goals


### PR DESCRIPTION
I'm back again, with more quality-of-life improvements (or at least I hope!).

This PR shows more information about the goals (video below). This is basically all straight out of CoqIDE:

* All focused goals are shown and numbered (also since Sublime has Unicode support I figure a full-width separator line is prettier). This is fairly important to me, because `eauto` or `inversion` often generate subgoals that I don't expect, and seeing them right away shows that I've gone in the wrong direction.
* Background goals, shelved goals (including evars) and admitted goals are counted separately in the "Goals:" line, which makes it easier to keep track of goals. Especially with evars the current goal counter is mostly useless.
* A `show_goals` setting (with values `"primary"` or `"current"`, the proposed default being `"current"`) allows reverting to the single-goal display, which I assume can be useful in inline mode to not blow up the size of the phantom.

https://user-images.githubusercontent.com/33732078/145720762-96dba1cf-d158-4435-95e2-e1882ed47168.mp4

This is all an extension of `format_response()` since the protocol part (specifically the `Goal` request) is already set up.

I'm not sure if the `sublime` module was deliberately not loaded in `coq.py`; if so we could add a function parameter, but it would need to travel pretty far down the call chain from `CoqPlugin.py` to `format_response()`.