### PR TITLE
Use is_applicable method of TextChangeListener

### DIFF
--- a/CoqPlugin.py
+++ b/CoqPlugin.py
@@ -853,14 +853,15 @@ if HAVE_ON_TEXT_CHANGED_SUPPORT:
 
     class CoqTextChangeListener(sublime_plugin.TextChangeListener):
 
-        # NOTE 2022/1/22: It might be nice to have an is_applicable method
-        # for this class like `ViewEventListener` has.  Alas, the Sublime devs
-        # didn't think of that, so we'll pick up changes from every Buffer.
-
         def on_text_changed(self, changes):
             modification_start_index = min(change.a.pt for change in changes)
             for view in self.buffer.views():
                 handle_view_modification(view, modification_start_index)
+
+        @classmethod
+        def is_applicable(cls, buffer):
+            return any(CoqViewEventListener.is_applicable(view.settings())
+                       for view in buffer.views())
 
 class CoqViewEventListener(sublime_plugin.ViewEventListener):
 


### PR DESCRIPTION
While browsing the doc I noticed that `TextChangeListener` now supports `is_applicable`. This should help a bit with performance since previously any change in any buffer would cause the Coq plugin to wake up. As far as I can tell adding the method should be backwards compatible because on older versions it's simply not going to be called?